### PR TITLE
Update Lithium support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'fabric-loom' version '1.7-SNAPSHOT'
+    id 'fabric-loom' version '1.8-SNAPSHOT'
     id 'maven-publish'
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -26,7 +26,7 @@ mm_version=0.20.0+1.21
 # Alloy Forgery: https://modrinth.com/mod/alloy-forgery
 af_version=2.4.1+1.21
 # leethium moment
-leetheum_version=mc1.21-0.13.0
+leetheum_version=mc1.21.1-0.14.3-fabric
 # Additional Entity Attributes
 # https://modrinth.com/mod/additionalentityattributes
 aea_version=1.8.0+1.21

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,16 +2,16 @@
 org.gradle.jvmargs=-Xmx2G
 # Fabric Properties
 # check these on https://fabricmc.net/develop/
-minecraft_version=1.21
+minecraft_version=1.21.1
 yarn_mappings=1.21+build.2
-loader_version=0.15.11
+loader_version=0.16.9
 # Mod Properties
 mod_version=0.7.2+1.21
 maven_group=nourl
 archives_base_name=mythicmetals-decorations
 # Dependencies
 # check this on https://modmuss50.me/fabric.html
-fabric_version=0.102.0+1.21
+fabric_version=0.110.0+1.21.1
 # https://www.curseforge.com/minecraft/mc-mods/roughly-enough-items/files/
 # https://maven.shedaniel.me/me/shedaniel/RoughlyEnoughItems-fabric/
 rei_version=16.0.729

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/nourl/mythicmetalsdecorations/mixin/MythicChestBlockEntityLithiumCompatMixin.java
+++ b/src/main/java/nourl/mythicmetalsdecorations/mixin/MythicChestBlockEntityLithiumCompatMixin.java
@@ -11,10 +11,7 @@ import org.spongepowered.asm.mixin.Shadow;
 @Mixin(MythicChestBlockEntity.class)
 public abstract class MythicChestBlockEntityLithiumCompatMixin implements LithiumInventory {
 
-    @Shadow
-    protected void setHeldStacks(DefaultedList<ItemStack> inventory) {
-        // hi mom
-    }
+    @Shadow private DefaultedList<ItemStack> inventory;
 
     @Override
     public int size() {
@@ -28,7 +25,7 @@ public abstract class MythicChestBlockEntityLithiumCompatMixin implements Lithiu
     }
 
     @Override
-    public void setInventoryLithium(DefaultedList<ItemStack> var1) {
-        setHeldStacks(var1);
+    public void setInventoryLithium(DefaultedList<ItemStack> inventory) {
+        this.inventory = inventory;
     }
 }

--- a/src/main/java/nourl/mythicmetalsdecorations/mixin/MythicChestBlockEntityLithiumCompatMixin.java
+++ b/src/main/java/nourl/mythicmetalsdecorations/mixin/MythicChestBlockEntityLithiumCompatMixin.java
@@ -11,7 +11,8 @@ import org.spongepowered.asm.mixin.Shadow;
 @Mixin(MythicChestBlockEntity.class)
 public abstract class MythicChestBlockEntityLithiumCompatMixin implements LithiumInventory {
 
-    @Shadow private DefaultedList<ItemStack> inventory;
+    @Shadow(remap = false)
+    private DefaultedList<ItemStack> inventory;
 
     @Override
     public int size() {

--- a/src/main/java/nourl/mythicmetalsdecorations/mixin/MythicChestBlockEntityLithiumCompatMixin.java
+++ b/src/main/java/nourl/mythicmetalsdecorations/mixin/MythicChestBlockEntityLithiumCompatMixin.java
@@ -1,6 +1,6 @@
 package nourl.mythicmetalsdecorations.mixin;
 
-import me.jellysquid.mods.lithium.api.inventory.LithiumInventory;
+import net.caffeinemc.mods.lithium.api.inventory.LithiumInventory;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.collection.DefaultedList;
 import nourl.mythicmetalsdecorations.blocks.chest.MythicChestBlock;

--- a/src/main/java/nourl/mythicmetalsdecorations/mixin/MythicChestBlockEntityLithiumCompatMixin.java
+++ b/src/main/java/nourl/mythicmetalsdecorations/mixin/MythicChestBlockEntityLithiumCompatMixin.java
@@ -6,9 +6,15 @@ import net.minecraft.util.collection.DefaultedList;
 import nourl.mythicmetalsdecorations.blocks.chest.MythicChestBlock;
 import nourl.mythicmetalsdecorations.blocks.chest.MythicChestBlockEntity;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
 
 @Mixin(MythicChestBlockEntity.class)
 public abstract class MythicChestBlockEntityLithiumCompatMixin implements LithiumInventory {
+
+    @Shadow
+    protected void setHeldStacks(DefaultedList<ItemStack> inventory) {
+        // hi mom
+    }
 
     @Override
     public int size() {
@@ -19,5 +25,10 @@ public abstract class MythicChestBlockEntityLithiumCompatMixin implements Lithiu
     @Override
     public DefaultedList<ItemStack> getInventoryLithium() {
         return ((MythicChestBlockEntity) (Object) this).getMythicChestInventory();
+    }
+
+    @Override
+    public void setInventoryLithium(DefaultedList<ItemStack> var1) {
+        setHeldStacks(var1);
     }
 }


### PR DESCRIPTION
hey metalsguy. 

This PR:
- Updates Lithium to the latest modrinth release, and all other required deps for such (can be seen in commit notes - this includes a change to 1.21.1, so you may want to move this to a different branch.)
- Updates imports for Lithium to the net.caffeinemc package
- Adds the missing method override for `setInventoryLithium`, necessary for proper interaction with Lithium optimized hoppers.
*Note*: This would have also been broken on previous versions as far as I can tell; it's not a newly added method on Lithium's end. I'm not sure if maybe this was excluded for a good reason, but this implementation seems to work fine in all cases.